### PR TITLE
Audio piping & Graceful shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -736,7 +736,7 @@ function setShuffle(state, message) {
 			message.react('👌');
 		},
 		function(error) {
-			if ('NO_ACTIVE_DEVICE' in error) {
+			if (error.toString().includes('NO_ACTIVE_DEVICE')) {
 				message.channel.send(embedDescriptionOnly.setDescription('Shuffle mode can only be changed when something is playing.'));
 			}
 			else {
@@ -753,7 +753,7 @@ function setRepeat(option, message) {
 			message.react('👌');
 		},
 		function(error) {
-			if ('NO_ACTIVE_DEVICE' in error) {
+			if (error.toString().includes('NO_ACTIVE_DEVICE')) {
 				message.channel.send(embedDescriptionOnly.setDescription('Repeat mode can only be changed when something is playing.'));
 			}
 			else {


### PR DESCRIPTION
Audio now get's played as stereo 16-bit PCM data from librespot through stdout to the discord.js dispatcher (type 'converted'). Still a little funky because pacing is a little off but at least it works.

In addition discord get's logged off gracefully through the API as well as librespot, where a 'ctrl-c' get's send to the process, when node received a SIGINT.